### PR TITLE
Update index.html to credit 2021 OSR website

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,10 @@ bigimg:
           <hr>
 
           <div align="left"><body><p align="justify"><small>
-          Images throughout this site are included with permission from <a href="https://undraw.co/search">Undraw</a>, <a href="https://thenounproject.com/">The Noun Project</a>, and <a href="https://ohbm.github.io/osr2021/volunteers/">OSR Volunteers</a>.
+          This website is based on and revises the substantial, creative efforts of the <a href="https://ohbm.github.io/osr2020/">2020 Open Science Room</a> co-chairs, Cassandra Gould van Praag and Stephan Heunis, and <a href="https://ohbm.github.io/osr2020/volunteers/">volunteers</a> to provide updated information about the 2021 OHBM Open Science Room. <br>
+		<a href="https://zenodo.org/badge/latestdoi/244895112"><img src="https://zenodo.org/badge/244895112.svg" alt="DOI"></a>
+	<br>
+	  Images throughout this site are included with permission from <a href="https://undraw.co/search">Undraw</a>, <a href="https://thenounproject.com/">The Noun Project</a>, and <a href="https://ohbm.github.io/osr2021/volunteers/">OSR Volunteers</a>.
           </small></p></body></div>
 
 


### PR DESCRIPTION
Includes shout-out to 2020 OSR co-chairs and DOI of the 2020 OSR website at the bottom of the main page.